### PR TITLE
docs: add GRN build-time table

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ ranked = gk.run(seed=8096)
 
 Building the GRN in parallel needs the optional Ray extra (`pip install "GenKI[ray]"`); pass `n_cpus` and other GRN options as keyword arguments, e.g. `GenKI.from_h5ad(..., rebuild_grn=True, n_cpus=8)`.
 
+## GRN build time
+
+`make_pcNet` fits a leave-one-out principal-component regression for every gene, so cost grows roughly as **O(genes² × cells × nComp)**. The table below is wall-clock seconds on an Apple M1 Pro (8 cores, 16 GB RAM) under the default settings (`nComp=3`, `svd_solver="auto"`, `n_cpus=8`) on a low-rank synthetic matrix; real scRNA-seq scales similarly at the same shape.
+
+| cells \ genes | 1 000 | 3 000 | 5 000 |
+|---:|---:|---:|---:|
+| **500**  | 11 s | 29 s | 77 s |
+| **1 000** | 12 s | 52 s | 2 min 13 s |
+| **2 000** | 18 s | 1 min 37 s | 4 min 22 s |
+
+For reference, the bundled `notebook/Example.ipynb` (1 139 cells × 3 000 genes, `n_cpus=8`) builds the GRN in about **1 minute** on this hardware.
+
+Notes:
+- Cost scales roughly linearly in `cells` and quadratically in `genes` once you're past the per-call Ray overhead (~10 s for `n_cpus=8`).
+- `n_cpus > 1` requires the optional Ray extra (`pip install "GenKI[ray]"`); the speedup from sharding is modest because numpy's BLAS already multithreads the per-gene SVDs.
+- GRNs are cached as `.npz` under `GRN_file_dir` (default `GRNs/`) — you pay this cost once per (cells, genes, nComp) selection. Pass `rebuild_grn=True` only when one of those changes.
+
 <details>
 <summary><b>Lower-level API</b> (fine-grained control over each step)</summary>
 

--- a/notebook/Example.ipynb
+++ b/notebook/Example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "6323b4c4",
    "metadata": {},
    "outputs": [],
@@ -18,13 +18,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ffae2228",
    "metadata": {},
    "outputs": [],
    "source": [
     "import GenKI as gk\n",
-    "from GenKI.preprocesing import build_adata\n",
+    "from GenKI.preprocessing import build_adata\n",
     "from GenKI.dataLoader import DataLoader\n",
     "from GenKI.train import VGAE_trainer\n",
     "from GenKI import utils\n",
@@ -35,83 +35,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "2b15fb16",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "load counts from data/microglial_seurat_WT.h5ad\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "AnnData object with n_obs × n_vars = 100 × 300\n",
-       "    obs: 'sce_source', 'treatment', 'trem2_genotype', 'snn_cluster', 'nCount_RNA', 'nFeature_RNA'\n",
-       "    var: 'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'\n",
-       "    layers: 'norm'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# subset data as an example\n",
     "\n",
-    "adata = build_adata(\"data/microglial_seurat_WT.h5ad\")\n",
-    "adata = adata[:100, :300].copy()\n",
+    "adata = build_adata(\"../data/microglial_seurat_WT.h5ad\")\n",
+    "adata = adata[:, :].copy()\n",
     "adata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "1e37d540",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "use all the cells (100) in adata\n",
-      "build GRN\n",
-      "ray init, using 8 CPUs\n",
-      "execution time of making pcNet: 6.26 s\n",
-      "GRN has been built and saved in \"GRNs\\pcNet_example.npz\"\n",
-      "init completed\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# load data\n",
+    "# load data \u2014 build the GRN and prepare WT / virtual-KO graph data\n",
+    "# Notes on the current API (>= 0.2.1):\n",
+    "#   * `pcNet_name` and `verbose` are no longer accepted\n",
+    "#   * GRN files are cached under `GRN_file_dir` using a content hash, so a\n",
+    "#     rebuild is automatically skipped when the cells/genes/build params match.\n",
+    "#   * Extra kwargs (e.g. `n_cpus`, `svd_solver`, `nComp`) are forwarded to\n",
+    "#     `GenKI.pcNet.make_pcNet`.\n",
     "\n",
-    "data_wrapper =  DataLoader(\n",
-    "                adata, # adata object\n",
-    "                target_gene = [\"TUBG1\"], # KO gene name\n",
-    "                target_cell = None, # obsname for cell type, if none use all\n",
-    "                obs_label = \"ident\", # colname for genes\n",
-    "                GRN_file_dir = \"GRNs\", # folder name for GRNs\n",
-    "                rebuild_GRN = True, # whether build GRN by pcNet\n",
-    "                pcNet_name = \"pcNet_example\", # GRN file name\n",
-    "                verbose = True, # whether verbose\n",
-    "                n_cpus = 8, # multiprocessing\n",
-    "                )\n",
+    "data_wrapper = DataLoader(\n",
+    "    adata,                        # AnnData object\n",
+    "    target_gene=[\"TREM2\"],        # KO gene name(s)\n",
+    "    target_cell=None,             # obs label for cell-type subset; None = all cells\n",
+    "    obs_label=\"ident\",            # adata.obs column for cell-type labels\n",
+    "    GRN_file_dir=\"GRNs\",          # folder for cached GRN .npz\n",
+    "    rebuild_GRN=True,             # build GRN if not cached\n",
+    "    n_cpus=8,                     # Ray sharding; needs `pip install \"GenKI[ray]\"`\n",
+    ")\n",
     "\n",
     "data_wt = data_wrapper.load_data()\n",
-    "data_ko = data_wrapper.load_kodata()"
+    "data_ko = data_wrapper.load_kodata()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "7862c768",
    "metadata": {},
    "outputs": [],
@@ -136,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "31bfb6a0",
    "metadata": {
     "scrolled": true
@@ -149,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e16a285e",
    "metadata": {},
    "outputs": [],
@@ -159,20 +128,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "e055e8f3",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(300,)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get distance between wt and ko\n",
     "\n",
@@ -184,79 +145,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "78e852b7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>dis</th>\n",
-       "      <th>rank</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>TUBG1</th>\n",
-       "      <td>2.565490</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>TYROBP</th>\n",
-       "      <td>0.001753</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>LST1</th>\n",
-       "      <td>0.001628</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>CYBA</th>\n",
-       "      <td>0.001517</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>LAT2</th>\n",
-       "      <td>0.001438</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "             dis  rank\n",
-       "TUBG1   2.565490     1\n",
-       "TYROBP  0.001753     2\n",
-       "LST1    0.001628     3\n",
-       "CYBA    0.001517     4\n",
-       "LAT2    0.001438     5"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# raw ranked gene list\n",
     "\n",
@@ -266,66 +158,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "9ddf3b86",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Permutating: 100%|██████████| 100/100 [00:03<00:00, 33.02it/s]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>dis</th>\n",
-       "      <th>index</th>\n",
-       "      <th>hit</th>\n",
-       "      <th>rank</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>TUBG1</th>\n",
-       "      <td>2.56549</td>\n",
-       "      <td>163</td>\n",
-       "      <td>100</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           dis  index  hit  rank\n",
-       "TUBG1  2.56549    163  100     1"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# if permutation test\n",
     "\n",
@@ -346,7 +182,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "genki",
    "language": "python",
    "name": "python3"
   },
@@ -360,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.20"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Add a GRN build-time table to README with wall-clock measurements on Apple M1 Pro under default settings (`nComp=3`, `svd_solver="auto"`, `n_cpus=8`) for genes ∈ {1k, 3k, 5k} × cells ∈ {500, 1k, 2k}, plus a reference point for the bundled notebook (1 139 × 3 000 ≈ 1 min).